### PR TITLE
Fixes #44 - deprecated warning logged only when using old prop

### DIFF
--- a/src/main/java/org/jgroups/protocols/kubernetes/KUBE_PING.java
+++ b/src/main/java/org/jgroups/protocols/kubernetes/KUBE_PING.java
@@ -178,7 +178,7 @@ public class KUBE_PING extends Discovery {
         boolean deprecatedDefined = isPropertyDefined(deprecated_name);
         if (propertyDefined && deprecatedDefined)
             log.warn("Both %s and %s are defined, %s is deprecated so please remove it", property_name, deprecated_name, deprecated_name);
-        else
+        else if (deprecatedDefined)
             log.warn("%s is deprecated, please remove it and use %s instead", deprecated_name, property_name);
     }
 


### PR DESCRIPTION
https://github.com/jgroups-extras/jgroups-kubernetes/issues/44