### PR TITLE
Updated demo with support for RBAC

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -179,11 +179,48 @@ http://www.github.com/belaban/IspnPerfTest[IspnPerfTest] via a YAML configuratio
 run a separate instance interactively and confirm that the instances have formed a cluster of 4. All instances
 are created in the default namespace and no labels are used.
 
-The YAML used is:
+Copy n' paste the snippet below in a terminal where kubectl is running against your K8S cluster
 
-.ispn-perf-test.yaml
-[source,yaml]
 ----
+# ---------------------------------------------------------------------
+# This demo assumes that RBAC is enabled on the Kubernetes cluster.
+#
+# The serviceaccount, clusterrole and clusterrolebinding provide
+# permission for the pods to query K8S api
+# ---------------------------------------------------------------------
+
+# Change to a Kubernetes namespace of your preference
+export TARGET_NAMESPACE=default
+
+kubectl create serviceaccount jgroups-kubeping-service-account -n $TARGET_NAMESPACE
+
+cat <<EOF | kubectl apply -f -
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: jgroups-kubeping-pod-reader
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: jgroups-kubeping-api-access
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: jgroups-kubeping-pod-reader
+subjects:
+- kind: ServiceAccount
+  name: jgroups-kubeping-service-account
+  namespace: $TARGET_NAMESPACE
+
+---
+
 apiVersion: v1
 items:
 - apiVersion: extensions/v1beta1
@@ -191,7 +228,7 @@ items:
   metadata:
     annotations:
     name: ispn-perf-test
-    namespace: default
+    namespace: $TARGET_NAMESPACE
   spec:
     replicas: 3
     selector:
@@ -200,6 +237,7 @@ items:
         labels:
           run: ispn-perf-test
       spec:
+        serviceAccountName: jgroups-kubeping-service-account
         containers:
         - args:
           - /opt/jgroups/IspnPerfTest/bin/kube.sh
@@ -216,7 +254,15 @@ items:
           terminationMessagePath: /dev/termination-log
 kind: List
 metadata: {}
+
+EOF
 ----
+
+To remove the resources when demo time is over:
+----
+kubectl delete deployment/ispn-perf-test clusterrolebinding/jgroups-kubeping-api-access clusterrole/jgroups-kubeping-pod-reader serviceaccount/jgroups-kubeping-service-account -n $TARGET_NAMESPACE
+----
+
 
 The image is `belaban/ispn_perf_test` which contains the IspnPerfTest project plus some scripts to start nodes. 3
 instances are started and the start command is `kube-debug.sh -nohup`; this launches the programs without the loop


### PR DESCRIPTION
When running the demo https://github.com/jgroups-extras/jgroups-kubernetes/blob/master/README.adoc#demo on a Kubernets cluster with RBAC enabled the Pods will complain with errors similar to

> WARNING: failed getting JSON response from Kubernetes Client[masterUrl=https://10.41.0.1:443/api/v1, headers={Authorization=#MASKED:849#}, connectTimeout=5000, readTimeout=30000, operationAttempts=3, operationSleep=1000, streamProvider=org.jgroups.protocols.kubernetes.stream.InsecureStreamProvider@24c21a36] for cluster [cfg], namespace [default], labels [null]; encountered [java.lang.Exception: 3 attempt(s) with a 1000ms sleep to execute [OpenStream] failed. Last failure was [java.io.IOException: Server returned HTTP response code: 403 for URL: https://10.41.0.1:443/api/v1/namespaces/default/pods]]

This PR amends the demo to support RBAC