### PR TITLE
Configurable JsonPath for pod owner

### DIFF
--- a/src/main/java/org/jgroups/protocols/kubernetes/Pod.java
+++ b/src/main/java/org/jgroups/protocols/kubernetes/Pod.java
@@ -4,13 +4,19 @@ public class Pod {
 
    private final String name;
    private final String ip;
-   private final String parentDeployment;
+   private final String podGroup;    // name of group of Pods during Rolling Update. There is two groups: new pods and old pods
+   private final boolean isReady;
 
 
-   public Pod(String name, String ip, String parentDeployment) {
+   public Pod(String name, String ip, String podGroup, boolean isReady) {
       this.name = name;
       this.ip = ip;
-      this.parentDeployment = parentDeployment;
+      this.podGroup = podGroup;
+      this.isReady = isReady;
+   }
+
+   public Pod(String name, String ip, String podGroup) {
+      this(name, ip, podGroup, false);
    }
 
    public String getName() {
@@ -21,8 +27,12 @@ public class Pod {
       return ip;
    }
 
-   public String getParentDeployment() {
-      return parentDeployment;
+   public String getPodGroup() {
+      return podGroup;
+   }
+
+   public boolean isReady() {
+      return isReady;
    }
 
    @Override
@@ -30,7 +40,7 @@ public class Pod {
       return "Pod{" +
             "name='" + name + '\'' +
             ", ip='" + ip + '\'' +
-            ", parentDeployment='" + parentDeployment + '\'' +
+            ", podGroup='" + podGroup + '\'' +
             '}';
    }
 
@@ -43,14 +53,14 @@ public class Pod {
 
       if (name != null ? !name.equals(pod.name) : pod.name != null) return false;
       if (ip != null ? !ip.equals(pod.ip) : pod.ip != null) return false;
-      return parentDeployment != null ? parentDeployment.equals(pod.parentDeployment) : pod.parentDeployment == null;
+      return podGroup != null ? podGroup.equals(pod.podGroup) : pod.podGroup == null;
    }
 
    @Override
    public int hashCode() {
       int result = name != null ? name.hashCode() : 0;
       result = 31 * result + (ip != null ? ip.hashCode() : 0);
-      result = 31 * result + (parentDeployment != null ? parentDeployment.hashCode() : 0);
+      result = 31 * result + (podGroup != null ? podGroup.hashCode() : 0);
       return result;
    }
 }

--- a/src/test/java/org/jgroups/ping/kube/test/ClientTest.java
+++ b/src/test/java/org/jgroups/ping/kube/test/ClientTest.java
@@ -37,4 +37,29 @@ public class ClientTest {
         assertEquals(2, numberOfPods);
     }
 
+    @Test
+    public void testParsingPodGroupPodTemplateHash() throws Exception {
+        //given
+        Client client = new TestClient("/pods_without_ports.json");
+
+        //when
+        String podGroup = client.getPods(null, null, false).get(0).getPodGroup();
+
+        //then
+        assertEquals("infinispan-simple-tutorials-kubernetes-5", podGroup);
+    }
+
+    @Test
+    public void testParsingPodGroupOpenshift() throws Exception {
+        //given
+        Client client = new TestClient("/replicaset_rolling_update.json");
+
+        //when
+        String podGroup = client.getPods(null, null, false).get(0).getPodGroup();
+
+        //then
+        assertEquals("6569c544b", podGroup);
+    }
+
+
 }

--- a/src/test/java/org/jgroups/ping/kube/test/StatusTest.java
+++ b/src/test/java/org/jgroups/ping/kube/test/StatusTest.java
@@ -1,13 +1,13 @@
 package org.jgroups.ping.kube.test;
 
-import static org.junit.Assert.assertEquals;
-
 import java.util.List;
 
 import org.jgroups.protocols.kubernetes.Client;
 import org.jgroups.protocols.kubernetes.Pod;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 /**
  * @author <a href="mailto:ulrich.romahn@gmail.com">Ulrich Romahn</a>
@@ -30,7 +30,10 @@ public class StatusTest {
         Client client = new TestClient(jsonFile);
         List<Pod> pods = client.getPods(null, null, false);
         Assert.assertNotNull(pods);
-        assertEquals(2, pods.size());
+        assertEquals(3, pods.size());
+        assertTrue(pods.get(0).isReady());
+        assertTrue(pods.get(1).isReady());
+        assertFalse(pods.get(2).isReady());
         String pod = pods.get(0).getIp();
         Assert.assertNotNull(pod);
     }

--- a/src/test/resources/replicaset_rolling_update.json
+++ b/src/test/resources/replicaset_rolling_update.json
@@ -1,0 +1,475 @@
+{
+  "kind": "PodList",
+  "apiVersion": "v1",
+  "metadata": {
+    "selfLink": "/api/v1/namespaces/default/pods",
+    "resourceVersion": "414433"
+  },
+  "items": [
+    {
+    "metadata": {
+      "name": "idp-6569c544b-f72mb",
+      "generateName": "idp-6569c544b-",
+      "namespace": "default",
+      "selfLink": "/api/v1/namespaces/default/pods/idp-6569c544b-f72mb",
+      "uid": "b5ab2340-a163-11e9-ba8c-001c42897fd6",
+      "resourceVersion": "406742",
+      "creationTimestamp": "2019-07-08T09:35:23Z",
+      "labels": {
+        "app": "idp-backend",
+        "group": "com.odin.idp",
+        "pod-template-hash": "6569c544b"
+      },
+      "ownerReferences": [{
+        "apiVersion": "apps/v1",
+        "kind": "ReplicaSet",
+        "name": "idp-6569c544b",
+        "uid": "b596013d-a163-11e9-ba8c-001c42897fd6",
+        "controller": true,
+        "blockOwnerDeletion": true
+      }
+      ]
+    },
+    "spec": {
+      "volumes": [{
+        "name": "default-token-w9wpf",
+        "secret": {
+          "secretName": "default-token-w9wpf",
+          "defaultMode": 420
+        }
+      }
+      ],
+      "containers": [{
+        "name": "idp-backend",
+        "image": "skeleton.repo.int.zone/idp-backend:1.0.1278",
+        "ports": [{
+          "name": "wildfly",
+          "containerPort": 8081,
+          "protocol": "TCP"
+        }, {
+          "name": "debug",
+          "containerPort": 8787,
+          "protocol": "TCP"
+        }, {
+          "name": "jgroups",
+          "containerPort": 7600,
+          "protocol": "TCP"
+        }
+        ],
+        "env": [{
+          "name": "OAUTH_KEY",
+          "valueFrom": {
+            "secretKeyRef": {
+              "name": "idp",
+              "key": "oauthkey"
+            }
+          }
+        }, {
+          "name": "OAUTH_SECRET",
+          "valueFrom": {
+            "secretKeyRef": {
+              "name": "idp",
+              "key": "oauthsecret"
+            }
+          }
+        }, {
+          "name": "JAVA_HEAP_SIZE",
+          "value": "-Xms512m -Xmx1024m"
+        }, {
+          "name": "DS_DB_NAME",
+          "value": "idpdb"
+        }, {
+          "name": "DS_LOGIN",
+          "valueFrom": {
+            "secretKeyRef": {
+              "name": "idp",
+              "key": "dslogin"
+            }
+          }
+        }, {
+          "name": "DS_PASSWORD",
+          "valueFrom": {
+            "secretKeyRef": {
+              "name": "idp",
+              "key": "dspassword"
+            }
+          }
+        }, {
+          "name": "JBOSS_ADMIN_PASSWORD",
+          "valueFrom": {
+            "secretKeyRef": {
+              "name": "idp",
+              "key": "jbossadminpassword"
+            }
+          }
+        }, {
+          "name": "DS_HOST",
+          "value": "postgres-postgresql.default.svc.cluster.local"
+        }, {
+          "name": "DS_PORT",
+          "value": "5432"
+        }, {
+          "name": "MIN_DB_POOL_SIZE",
+          "value": "1"
+        }, {
+          "name": "MAX_DB_POOL_SIZE",
+          "value": "16"
+        }, {
+          "name": "JDBC_CONNECTION_PARAMS",
+          "value": "?ApplicationName=idp-app"
+        }, {
+          "name": "KEYCLOAK_LOGLEVEL",
+          "value": "DEBUG"
+        }
+        ],
+        "resources": {
+          "limits": {
+            "cpu": "8",
+            "memory": "4Gi"
+          },
+          "requests": {
+            "cpu": "50m",
+            "memory": "1Gi"
+          }
+        },
+        "volumeMounts": [{
+          "name": "default-token-w9wpf",
+          "readOnly": true,
+          "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+        }
+        ],
+        "livenessProbe": {
+          "httpGet": {
+            "path": "/rest/application/livenessProbe",
+            "port": "wildfly",
+            "scheme": "HTTPS"
+          },
+          "initialDelaySeconds": 40,
+          "timeoutSeconds": 5,
+          "periodSeconds": 60,
+          "successThreshold": 1,
+          "failureThreshold": 30000
+        },
+        "readinessProbe": {
+          "httpGet": {
+            "path": "/rest/application/readinessProbe",
+            "port": "wildfly",
+            "scheme": "HTTPS"
+          },
+          "initialDelaySeconds": 40,
+          "timeoutSeconds": 5,
+          "periodSeconds": 5,
+          "successThreshold": 1,
+          "failureThreshold": 30000
+        },
+        "terminationMessagePath": "/dev/termination-log",
+        "terminationMessagePolicy": "File",
+        "imagePullPolicy": "IfNotPresent"
+      }
+      ],
+      "restartPolicy": "Always",
+      "terminationGracePeriodSeconds": 30,
+      "dnsPolicy": "ClusterFirst",
+      "serviceAccountName": "default",
+      "serviceAccount": "default",
+      "nodeName": "kumaster-3a8cddfe6d8a.aqa.int.zone",
+      "securityContext": {},
+      "imagePullSecrets": [{
+        "name": "a8n-docker-registry"
+      }
+      ],
+      "schedulerName": "default-scheduler",
+      "tolerations": [{
+        "key": "node.kubernetes.io/not-ready",
+        "operator": "Exists",
+        "effect": "NoExecute",
+        "tolerationSeconds": 300
+      }, {
+        "key": "node.kubernetes.io/unreachable",
+        "operator": "Exists",
+        "effect": "NoExecute",
+        "tolerationSeconds": 300
+      }
+      ],
+      "priority": 0
+    },
+    "status": {
+      "phase": "Running",
+      "conditions": [{
+        "type": "Initialized",
+        "status": "True",
+        "lastProbeTime": null,
+        "lastTransitionTime": "2019-07-08T09:35:23Z"
+      }, {
+        "type": "Ready",
+        "status": "True",
+        "lastProbeTime": null,
+        "lastTransitionTime": "2019-07-08T09:36:48Z"
+      }, {
+        "type": "ContainersReady",
+        "status": "True",
+        "lastProbeTime": null,
+        "lastTransitionTime": "2019-07-08T09:36:48Z"
+      }, {
+        "type": "PodScheduled",
+        "status": "True",
+        "lastProbeTime": null,
+        "lastTransitionTime": "2019-07-08T09:35:23Z"
+      }
+      ],
+      "hostIP": "10.26.163.91",
+      "podIP": "127.0.0.1",
+      "startTime": "2019-07-08T09:35:23Z",
+      "containerStatuses": [{
+        "name": "idp-backend",
+        "state": {
+          "running": {
+            "startedAt": "2019-07-08T09:35:31Z"
+          }
+        },
+        "lastState": {},
+        "ready": true,
+        "restartCount": 0,
+        "image": "skeleton.repo.int.zone/idp-backend:1.0.1278",
+        "imageID": "docker-pullable://skeleton.repo.int.zone/idp-backend@sha256:2079cd6f976f0c7b841db2ca00cc5a704c9b781cc2aaa071eab893e9188a7698",
+        "containerID": "docker://408f06380d86be10ad1bd553d9cea47d2278c1af39c7ad4e9833386aa716e436"
+      }
+      ],
+      "qosClass": "Burstable"
+    }
+  },
+    {
+      "metadata": {
+        "name": "idp-aae51544b-a80bc",
+        "generateName": "idp-aae51544b-",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/pods/idp-aae51544b-a80bc",
+        "uid": "ce525630-a163-11e9-ba8c-001c42897fff",
+        "resourceVersion": "406749",
+        "creationTimestamp": "2019-07-08T09:39:23Z",
+        "labels": {
+          "app": "idp-backend",
+          "group": "com.odin.idp",
+          "pod-template-hash": "6569c556b"
+        },
+        "ownerReferences": [{
+          "apiVersion": "apps/v1",
+          "kind": "ReplicaSet",
+          "name": "idp-aae51544b",
+          "uid": "9eb0013d-a163-11e9-ba8c-001c42897fd6",
+          "controller": true,
+          "blockOwnerDeletion": true
+        }
+        ]
+      },
+      "spec": {
+        "volumes": [{
+          "name": "default-token-w9wpf",
+          "secret": {
+            "secretName": "default-token-w9wpf",
+            "defaultMode": 420
+          }
+        }
+        ],
+        "containers": [{
+          "name": "idp-backend",
+          "image": "skeleton.repo.int.zone/idp-backend:1.0.1279",
+          "ports": [{
+            "name": "wildfly",
+            "containerPort": 8081,
+            "protocol": "TCP"
+          }, {
+            "name": "debug",
+            "containerPort": 8787,
+            "protocol": "TCP"
+          }, {
+            "name": "jgroups",
+            "containerPort": 7600,
+            "protocol": "TCP"
+          }
+          ],
+          "env": [{
+            "name": "OAUTH_KEY",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "idp",
+                "key": "oauthkey"
+              }
+            }
+          }, {
+            "name": "OAUTH_SECRET",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "idp",
+                "key": "oauthsecret"
+              }
+            }
+          }, {
+            "name": "JAVA_HEAP_SIZE",
+            "value": "-Xms512m -Xmx1024m"
+          }, {
+            "name": "DS_DB_NAME",
+            "value": "idpdb"
+          }, {
+            "name": "DS_LOGIN",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "idp",
+                "key": "dslogin"
+              }
+            }
+          }, {
+            "name": "DS_PASSWORD",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "idp",
+                "key": "dspassword"
+              }
+            }
+          }, {
+            "name": "JBOSS_ADMIN_PASSWORD",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "idp",
+                "key": "jbossadminpassword"
+              }
+            }
+          }, {
+            "name": "DS_HOST",
+            "value": "postgres-postgresql.default.svc.cluster.local"
+          }, {
+            "name": "DS_PORT",
+            "value": "5432"
+          }, {
+            "name": "MIN_DB_POOL_SIZE",
+            "value": "1"
+          }, {
+            "name": "MAX_DB_POOL_SIZE",
+            "value": "16"
+          }, {
+            "name": "JDBC_CONNECTION_PARAMS",
+            "value": "?ApplicationName=idp-app"
+          }, {
+            "name": "KEYCLOAK_LOGLEVEL",
+            "value": "DEBUG"
+          }
+          ],
+          "resources": {
+            "limits": {
+              "cpu": "8",
+              "memory": "4Gi"
+            },
+            "requests": {
+              "cpu": "50m",
+              "memory": "1Gi"
+            }
+          },
+          "volumeMounts": [{
+            "name": "default-token-w9wpf",
+            "readOnly": true,
+            "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+          }
+          ],
+          "livenessProbe": {
+            "httpGet": {
+              "path": "/rest/application/livenessProbe",
+              "port": "wildfly",
+              "scheme": "HTTPS"
+            },
+            "initialDelaySeconds": 40,
+            "timeoutSeconds": 5,
+            "periodSeconds": 60,
+            "successThreshold": 1,
+            "failureThreshold": 30000
+          },
+          "readinessProbe": {
+            "httpGet": {
+              "path": "/rest/application/readinessProbe",
+              "port": "wildfly",
+              "scheme": "HTTPS"
+            },
+            "initialDelaySeconds": 40,
+            "timeoutSeconds": 5,
+            "periodSeconds": 5,
+            "successThreshold": 1,
+            "failureThreshold": 30000
+          },
+          "terminationMessagePath": "/dev/termination-log",
+          "terminationMessagePolicy": "File",
+          "imagePullPolicy": "IfNotPresent"
+        }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "kumaster-3a8cddfe6d8a.aqa.int.zone",
+        "securityContext": {},
+        "imagePullSecrets": [{
+          "name": "a8n-docker-registry"
+        }
+        ],
+        "schedulerName": "default-scheduler",
+        "tolerations": [{
+          "key": "node.kubernetes.io/not-ready",
+          "operator": "Exists",
+          "effect": "NoExecute",
+          "tolerationSeconds": 300
+        }, {
+          "key": "node.kubernetes.io/unreachable",
+          "operator": "Exists",
+          "effect": "NoExecute",
+          "tolerationSeconds": 300
+        }
+        ],
+        "priority": 0
+      },
+      "status": {
+        "phase": "Running",
+        "conditions": [{
+          "type": "Initialized",
+          "status": "True",
+          "lastProbeTime": null,
+          "lastTransitionTime": "2019-07-08T09:35:23Z"
+        }, {
+          "type": "Ready",
+          "status": "True",
+          "lastProbeTime": null,
+          "lastTransitionTime": "2019-07-08T09:36:48Z"
+        }, {
+          "type": "ContainersReady",
+          "status": "True",
+          "lastProbeTime": null,
+          "lastTransitionTime": "2019-07-08T09:36:48Z"
+        }, {
+          "type": "PodScheduled",
+          "status": "True",
+          "lastProbeTime": null,
+          "lastTransitionTime": "2019-07-08T09:35:23Z"
+        }
+        ],
+        "hostIP": "10.26.163.91",
+        "podIP": "127.0.0.1",
+        "startTime": "2019-07-08T09:35:23Z",
+        "containerStatuses": [{
+          "name": "idp-backend",
+          "state": {
+            "running": {
+              "startedAt": "2019-07-08T09:35:31Z"
+            }
+          },
+          "lastState": {},
+          "ready": true,
+          "restartCount": 0,
+          "image": "skeleton.repo.int.zone/idp-backend:1.0.1279",
+          "imageID": "docker-pullable://skeleton.repo.int.zone/idp-backend@sha256:aaaaad6f976f0c7b841db2ca00cc5a704c9b781cc2aaa071eab893e9188a7698",
+          "containerID": "docker://aaaaaa380d86be10ad1bd553d9cea47d2278c1af39c7ad4e9833386aa716e436"
+        }
+        ],
+        "qosClass": "Burstable"
+      }
+    }
+
+  ]
+}


### PR DESCRIPTION
This is a fix for https://github.com/jgroups-extras/jgroups-kubernetes/issues/50
New property 'podOwnerJsonPath' added with JsonPath to pod owner (ReplicaSet or OpenShift Deployment) relative to pod json node. Default value is "$.metadata.labels.deployment" to keep backward compatibility.
For kubernetes w/o OpenShift, property value should be set to "$.metadata.ownerReferences[?(@['kind'] == 'ReplicaSet')].name"

Please note new dependency is added, com.jayway.jsonpath:json-path. It should be placed to JBoss module somehow, by adding a new jar or by a shaded jar, please advice how to do it.