### PR TITLE
Resolves #39: Occasional NPE on shutdown: remove unnecessary nulling …

### DIFF
--- a/src/main/java/org/jgroups/protocols/kubernetes/KUBE_PING.java
+++ b/src/main/java/org/jgroups/protocols/kubernetes/KUBE_PING.java
@@ -193,11 +193,6 @@ public class KUBE_PING extends Discovery {
                 || System.getenv(property_name) != null;
     }
 
-    @Override public void destroy() {
-        client=null;
-        super.destroy();
-    }
-
     private PhysicalAddress getCurrentPhysicalAddress(Address addr) {
         return (PhysicalAddress)down(new Event(Event.GET_PHYSICAL_ADDRESS, addr));
     }


### PR DESCRIPTION
…of fields in Protocol.destroy()

This can result in NPE in `findMembers(..)` or `fetchFromKube` mgmt operation.