### PR TITLE
Sanitize log message - remove Authorization HTTP header values

### DIFF
--- a/src/main/java/org/jgroups/protocols/kubernetes/Utils.java
+++ b/src/main/java/org/jgroups/protocols/kubernetes/Utils.java
@@ -11,6 +11,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.logging.Level;
@@ -153,6 +154,24 @@ public final class Utils {
             cl.close();
         } catch (Exception e) {
         }
+    }
+
+    /**
+     * Sanitizes a map of HTTP headers - all entries where the key equals "Authorization" (case-insensitive) are
+     * overridden to mask the original authorization data.
+     *
+     * @param headers HTTP header map
+     * @return map where all "Authorization" entries are masked
+     */
+    public static Map<String, String> sanitizeHttpHeaders(Map<String, String> headers) {
+        HashMap<String, String> newHeaders = new HashMap<>(headers);
+        // Iterate over all keys to find all case combinations
+        newHeaders.keySet().forEach(key -> {
+            if (key != null && key.equalsIgnoreCase("Authorization")) {
+                newHeaders.put(key, "***");
+            }
+        });
+        return newHeaders;
     }
 
     private Utils() {}

--- a/src/main/java/org/jgroups/protocols/kubernetes/stream/BaseStreamProvider.java
+++ b/src/main/java/org/jgroups/protocols/kubernetes/stream/BaseStreamProvider.java
@@ -1,5 +1,7 @@
 package org.jgroups.protocols.kubernetes.stream;
 
+import org.jgroups.protocols.kubernetes.Utils;
+
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
@@ -12,7 +14,8 @@ public abstract class BaseStreamProvider implements StreamProvider {
 
     public URLConnection openConnection(String url, Map<String, String> headers, int connectTimeout, int readTimeout) throws IOException {
         if (log.isLoggable(Level.FINE)) {
-            log.log(Level.FINE, String.format("%s opening connection: url [%s], headers [%s], connectTimeout [%s], readTimeout [%s]", getClass().getSimpleName(), url, headers, connectTimeout, readTimeout));
+            log.log(Level.FINE, String.format("%s opening connection: url [%s], headers [%s], connectTimeout [%s], readTimeout [%s]",
+                    getClass().getSimpleName(), url, Utils.sanitizeHttpHeaders(headers), connectTimeout, readTimeout));
         }
         URLConnection connection = new URL(url).openConnection();
         if (headers != null) {

--- a/src/test/java/org/jgroups/protocols/kubernetes/UtilsTest.java
+++ b/src/test/java/org/jgroups/protocols/kubernetes/UtilsTest.java
@@ -1,0 +1,21 @@
+package org.jgroups.protocols.kubernetes;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import java.util.Map;
+
+public class UtilsTest {
+
+    @Test
+    public void testSanitizeHttpHeaders() {
+        Map<String, String> sanitized = Utils.sanitizeHttpHeaders(Map.of(
+                "Host", "jgroups.org",
+                "Authorization", "Basic abcd",
+                "authorization", "Bearer abcd"
+        ));
+        Assertions.assertThat(sanitized.get("Host")).isEqualTo("jgroups.org");
+        Assertions.assertThat(sanitized.get("Authorization")).isEqualTo("***");
+        Assertions.assertThat(sanitized.get("authorization")).isEqualTo("***");
+    }
+}


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-26516
No upstream required.

Log message was reported to be:

```
10:25:07,745 FINE  [org.jgroups.protocols.kubernetes.stream.BaseStreamProvider] (ServerService Thread Pool -- 60) TokenStreamProvider opening connection: url [https://172.30.0.1:443/api/v1/namespaces/fburzigo/pods], headers [{Authorization=Bearer <real token>...
```

This overrides the Authorization header value with "***".